### PR TITLE
Support Linux Mint 19 and other distros

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -33,12 +33,8 @@ function getRuntimeIdLinux(distributionName: string, distributionVersion: string
 
 			break;
 		case 'linuxmint':
-			if (distributionVersion.startsWith('18')) {
-				// Linux Mint 18 is binary compatible with Ubuntu 16.04
-				return Runtime.Ubuntu_16;
-			}
-
-			break;
+			// Current versions of Linux Mint are binary compatible with Ubuntu 16.04
+			return Runtime.Ubuntu_16;
 		case 'centos':
 		case 'ol':
 			// Oracle Linux is binary compatible with CentOS
@@ -59,10 +55,11 @@ function getRuntimeIdLinux(distributionName: string, distributionVersion: string
 			}
 			break;
 		default:
-			return Runtime.Unknown;
+			// Default to Ubuntu_16 to try to support other Linux distributions
+			return Runtime.Ubuntu_16;
 	}
 
-	return Runtime.Unknown;
+	return Runtime.Ubuntu_16;
 }
 
 /**


### PR DESCRIPTION
Update the code to support Linux Mint 19 and to try to use Ubuntu_16 when we find an unknown Linux distribution since it will often work