### PR TITLE
Feature to retry failed download/install operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-downloader",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Download a file and decompress it. Designed for use with Sql Operations Studio",
   "main": "out/main.js",
   "typings": "out/main",
@@ -25,6 +25,7 @@
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "mkdirp": "^0.5.1",
+    "promise-retry": "^1.1.1",
     "tmp": "^0.0.33"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-downloader",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "description": "Download a file and decompress it. Designed for use with Sql Operations Studio",
   "main": "out/main.js",
   "typings": "out/main",
@@ -13,6 +13,7 @@
   "author": "anthonydresser",
   "license": "ISC",
   "devDependencies": {
+    "@types/async-retry": "^1.4.1",
     "@types/node": "^9.4.6",
     "@types/tmp": "^0.0.33",
     "tslint": "^5.16.0",
@@ -20,12 +21,12 @@
     "typescript": "^2.7.2"
   },
   "dependencies": {
+    "async-retry": "^1.2.3",
     "decompress": "^4.2.0",
     "eventemitter2": "^5.0.1",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "mkdirp": "^0.5.1",
-    "promise-retry": "^1.1.1",
     "tmp": "^0.0.33"
   },
   "repository": {

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -22,7 +22,7 @@ export class HttpClient {
     /*
      * Downloads a file and stores the result in the temp file inside the package object
      */
-    public async downloadFile(urlString: string, pkg: IPackage, proxy?: string, strictSSL?: boolean): Promise<void> {
+    public downloadFile(urlString: string, pkg: IPackage, proxy?: string, strictSSL?: boolean): Promise<void> {
         const url = parseUrl(urlString);
         let options = this.getHttpClientOptions(url, proxy, strictSSL);
         let clientRequest = url.protocol === 'http:' ? http.request : https.request;

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -19,10 +19,10 @@ export class HttpClient {
 
     public readonly eventEmitter = new EventEmitter({ wildcard: true });
 
-   /*
-    * Downloads a file and stores the result in the temp file inside the package object
-    */
-    public downloadFile(urlString: string, pkg: IPackage, proxy?: string, strictSSL?: boolean): Promise<void> {
+    /*
+     * Downloads a file and stores the result in the temp file inside the package object
+     */
+    public async downloadFile(urlString: string, pkg: IPackage, proxy?: string, strictSSL?: boolean): Promise<void> {
         const url = parseUrl(urlString);
         let options = this.getHttpClientOptions(url, proxy, strictSSL);
         let clientRequest = url.protocol === 'http:' ? http.request : https.request;
@@ -73,10 +73,10 @@ export class HttpClient {
 
         if (url.protocol === 'https:') {
             let httpsOptions: https.RequestOptions = {
-                    host: url.hostname,
-                    path: url.path,
-                    agent: agent,
-                    port: +url.port
+                host: url.hostname,
+                path: url.path,
+                agent: agent,
+                port: +url.port
             };
             options = httpsOptions;
         }
@@ -84,9 +84,9 @@ export class HttpClient {
         return options;
     }
 
-   /*
-    * Calculate the download percentage and stores in the progress object
-    */
+    /*
+     * Calculate the download percentage and stores in the progress object
+     */
     public handleDataReceivedEvent(progress: IDownloadProgress, data: any): void {
         progress.downloadedBytes += data.length;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -48,24 +48,24 @@ export interface IRetryOptions {
     /**
      * The maximum amount of times to retry the operation. Default is 10. Setting this to 1 means do it once, then retry it once.
      */
-    retries: number;
+    retries?: number;
     /**
      * The exponential factor to use. Default is 2.
      */
-    factor: number;
+    factor?: number;
     /**
      * The number of milliseconds before starting the first retry. Default is 1000.
      */
-    minTimeout: number;
+    minTimeout?: number;
     /**
      * The maximum number of milliseconds between two retries. Once this value is reached the timeout between successive 
      * retries is the value configured for this field. Default is Infinity.
      */
-    maxTimeout: number;
+    maxTimeout?: number;
     /**
      * Randomizes the timeouts by multiplying with a factor between 1 to 2. Default is false.
      */
-    randomize: boolean;
+    randomize?: boolean;
 }
 
 export const enum Events {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,6 +32,15 @@ export interface IConfig {
     proxy: string;
     strictSSL: boolean;
     executableFiles: Array<string>;
+    /**
+     * Optional configuration for retries.
+     * Enabled flag is used to turn it on or off. It is off by default.
+     * Options object is a pass through configuration to the http://npmjs.org/retry module.
+     */
+    retry?: {
+        enabled: boolean,
+        options: any
+    }
 }
 
 export const enum Events {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,10 +37,35 @@ export interface IConfig {
      * Enabled flag is used to turn it on or off. It is off by default.
      * Options object is a pass through configuration to the http://npmjs.org/retry module.
      */
-    retry?: {
-        enabled: boolean,
-        options: any
-    }
+    retry?: IRetryOptions;
+}
+
+/**
+ * Retry configuration passed to the http://npmjs.org/promise-retry module.
+ * See http://npmjs.org/retry for more details on these options.
+ */
+export interface IRetryOptions {
+    /**
+     * The maximum amount of times to retry the operation. Default is 10. Setting this to 1 means do it once, then retry it once.
+     */
+    retries: number;
+    /**
+     * The exponential factor to use. Default is 2.
+     */
+    factor: number;
+    /**
+     * The number of milliseconds before starting the first retry. Default is 1000.
+     */
+    minTimeout: number;
+    /**
+     * The maximum number of milliseconds between two retries. Once this value is reached the timeout between successive 
+     * retries is the value configured for this field. Default is Infinity.
+     */
+    maxTimeout: number;
+    /**
+     * Randomizes the timeouts by multiplying with a factor between 1 to 2. Default is false.
+     */
+    randomize: boolean;
 }
 
 export const enum Events {

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -153,7 +153,7 @@ export class ServiceDownloadProvider {
                         console.warn(`[${(new Date()).toLocaleTimeString('en-US', { hour12: false })}] `
                                      + `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
                     }
-                    // throw back any other error so it can get retried upon by AsyncRetry as appropriate
+                    // throw back any other error so it can get retried by AsyncRetry as appropriate
                     throw error;
                 }
             },

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -91,8 +91,8 @@ export class ServiceDownloadProvider {
             tmpFile: undefined
         };
 
-		const existsAsync = promisify(fs.exists);
-		const unlinkAsync = promisify(fs.unlink);
+        const existsAsync = promisify(fs.exists);
+        const unlinkAsync = promisify(fs.unlink);
         const downloadAndInstall: () => Promise<void> = async () => {
             try {
                 pkg.tmpFile = await this.createTempFile(pkg);
@@ -155,7 +155,7 @@ async function withRetry(promiseToExecute: () => Promise<any>, retryOptions: IRe
                 }
                 if (attemptNo <= retryOptions.retries) {
                     console.warn(`[${(new Date()).toLocaleTimeString('en-US', { hour12: false })}] `
-                                 + `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
+                        + `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
                 }
                 // throw back any other error so it can get retried by asyncRetry as appropriate
                 throw error;

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -136,7 +136,7 @@ export class ServiceDownloadProvider {
     private async withRetry(promiseToExecute: () => Promise<any>, retryOptions: IRetryOptions = { retries: 0 }): Promise<any> {
         // wrap function execution with a retry promise
         // by default, it retries 10 times while backing off exponentially.
-        // retryOptions parameter can be used to configure, how many and how often the retries happen.
+        // retryOptions parameter can be used to configure how many and how often the retries happen.
         // https://www.npmjs.com/package/promise-retry
         return await AsyncRetry<any>(
             async (bail: (e: Error) => void, attemptNo: number) => {

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -93,7 +93,8 @@ export class ServiceDownloadProvider {
         const downloadAndInstall: () => Promise<void> = async () => {
             try {
                 pkg.tmpFile = await this.createTempFile(pkg);
-                console.info(`\tdownloading the package: ${pkg.url} to file: ${pkg.tmpFile.name}`);
+				console.info(`\tdownloading the package: ${pkg.url}`);
+				console.info(`\t                to file: ${pkg.tmpFile.name}`);
                 await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
                 console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
                 await this.install(pkg);
@@ -107,8 +108,8 @@ export class ServiceDownloadProvider {
             }
         };
 
-        if (this._config.retry && this._config.retry.enabled) {
-            await this.withRetry(downloadAndInstall, this._config.retry.options);
+        if (this._config.retry) {
+            await this.withRetry(downloadAndInstall, this._config.retry);
         } else {
             await downloadAndInstall();
         }

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -144,7 +144,7 @@ export class ServiceDownloadProvider {
                 return await promiseToExecute();
             } catch (error) {
                 console.warn(`${(new Date()).toLocaleTimeString()}:attempt number:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
-                retry(error);
+                await retry(error);
             }
         });
     }

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -14,142 +14,150 @@ import { Runtime, getRuntimeDisplayName } from './platform';
 import { IConfig, IPackage, Events, IRetryOptions } from './interfaces';
 import { HttpClient } from './httpClient';
 import { PlatformNotSupportedError, DistributionNotSupportedError } from './errors';
-
+import * as AsyncRetry from 'async-retry';
 /*
 * Service Download Provider class which handles downloading the service client
 */
 export class ServiceDownloadProvider {
 
-	private httpClient = new HttpClient();
-	public readonly eventEmitter = new EventEmitter({ wildcard: true });
+    private httpClient = new HttpClient();
+    public readonly eventEmitter = new EventEmitter({ wildcard: true });
 
-	constructor(
-		private _config: IConfig
-	) {
-		// Ensure our temp files get cleaned up in case of error.
-		tmp.setGracefulCleanup();
-		this.httpClient.eventEmitter.onAny((e, ...args) => {
-			this.eventEmitter.emit(e, ...args);
-		});
-	}
+    constructor(
+        private _config: IConfig
+    ) {
+        // Ensure our temp files get cleaned up in case of error.
+        tmp.setGracefulCleanup();
+        this.httpClient.eventEmitter.onAny((e, ...args) => {
+            this.eventEmitter.emit(e, ...args);
+        });
+    }
 
     /**
      * Returns the download url for given platform
      */
-	public getDownloadFileName(platform: Runtime): string {
-		let fileNamesJson = this._config.downloadFileNames;
-		let fileName = fileNamesJson[platform];
+    public getDownloadFileName(platform: Runtime): string {
+        let fileNamesJson = this._config.downloadFileNames;
+        let fileName = fileNamesJson[platform];
 
-		if (fileName === undefined) {
-			if (process.platform === 'linux') {
-				throw new DistributionNotSupportedError('Unsupported linux distribution', process.platform, platform.toString());
-			} else {
-				throw new PlatformNotSupportedError(`Unsupported platform: ${process.platform}`, process.platform);
-			}
-		}
+        if (fileName === undefined) {
+            if (process.platform === 'linux') {
+                throw new DistributionNotSupportedError('Unsupported linux distribution', process.platform, platform.toString());
+            } else {
+                throw new PlatformNotSupportedError(`Unsupported platform: ${process.platform}`, process.platform);
+            }
+        }
 
-		return fileName;
-	}
+        return fileName;
+    }
 
     /**
      * Returns SQL tools service installed folder.
      */
-	public getInstallDirectory(platform: Runtime): string {
-		let basePath = this._config.installDirectory;
-		let versionFromConfig = this._config.version;
-		basePath = basePath.replace('{#version#}', versionFromConfig);
-		basePath = basePath.replace('{#platform#}', getRuntimeDisplayName(platform));
-		if (!fs.existsSync(basePath)) {
-			mkdirp.sync(basePath);
-		}
+    public getInstallDirectory(platform: Runtime): string {
+        let basePath = this._config.installDirectory;
+        let versionFromConfig = this._config.version;
+        basePath = basePath.replace('{#version#}', versionFromConfig);
+        basePath = basePath.replace('{#platform#}', getRuntimeDisplayName(platform));
+        if (!fs.existsSync(basePath)) {
+            mkdirp.sync(basePath);
+        }
 
-		return basePath;
-	}
+        return basePath;
+    }
 
-	private getGetDownloadUrl(fileName: string): string {
-		let baseDownloadUrl = this._config.downloadUrl;
-		let version = this._config.version;
-		baseDownloadUrl = baseDownloadUrl.replace('{#version#}', version);
-		baseDownloadUrl = baseDownloadUrl.replace('{#fileName#}', fileName);
-		return baseDownloadUrl;
-	}
+    private getGetDownloadUrl(fileName: string): string {
+        let baseDownloadUrl = this._config.downloadUrl;
+        let version = this._config.version;
+        baseDownloadUrl = baseDownloadUrl.replace('{#version#}', version);
+        baseDownloadUrl = baseDownloadUrl.replace('{#fileName#}', fileName);
+        return baseDownloadUrl;
+    }
 
     /**
      * Downloads the service and decompress it in the install folder.
      */
-	public async installService(platform: Runtime): Promise<boolean> {
-		const proxy = this._config.proxy;
-		const strictSSL = this._config.strictSSL;
-		const fileName = this.getDownloadFileName(platform);
-		const installDirectory = this.getInstallDirectory(platform);
-		const urlString = this.getGetDownloadUrl(fileName);
+    public async installService(platform: Runtime): Promise<boolean> {
+        const proxy = this._config.proxy;
+        const strictSSL = this._config.strictSSL;
+        const fileName = this.getDownloadFileName(platform);
+        const installDirectory = this.getInstallDirectory(platform);
+        const urlString = this.getGetDownloadUrl(fileName);
 
-		const pkg: IPackage = {
-			installPath: installDirectory,
-			url: urlString,
-			tmpFile: undefined
-		};
+        const pkg: IPackage = {
+            installPath: installDirectory,
+            url: urlString,
+            tmpFile: undefined
+        };
 
-		const downloadAndInstall: () => Promise<void> = async () => {
-			try {
-				pkg.tmpFile = await this.createTempFile(pkg);
-				console.info(`\tdownloading the package: ${pkg.url}`);
-				console.info(`\t                to file: ${pkg.tmpFile.name}`);
-				await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
-				console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
-				await this.install(pkg);
+        const downloadAndInstall: () => Promise<void> = async () => {
+            try {
+                pkg.tmpFile = await this.createTempFile(pkg);
+                console.info(`\tdownloading the package: ${pkg.url}`);
+                console.info(`\t                to file: ${pkg.tmpFile.name}`);
+                await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
+                console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
+                await this.install(pkg);
 
-			} finally {
-				// remove the downloaded package file
-				if (fs.existsSync(pkg.tmpFile.name)) {
-					fs.unlinkSync(pkg.tmpFile.name);
-					console.info(`\tdeleted the package file: ${pkg.tmpFile.name}`);
-				}
-			}
-		};
+            } finally {
+                // remove the downloaded package file
+                if (fs.existsSync(pkg.tmpFile.name)) {
+                    fs.unlinkSync(pkg.tmpFile.name);
+                    console.info(`\tdeleted the package file: ${pkg.tmpFile.name}`);
+                }
+            }
+        };
 
-		// if this._config.retry is not defined then this.withRetry defaults to number of retries of 0
-		// which is same as without retries.
-		await this.withRetry(downloadAndInstall, this._config.retry);
-		return true;
-	}
+        // if this._config.retry is not defined then this.withRetry defaults to number of retries of 0
+        // which is same as without retries.
+        await this.withRetry(downloadAndInstall, this._config.retry);
+        return true;
+    }
 
-	private createTempFile(pkg: IPackage): Promise<tmp.SynchrounousResult> {
-		return new Promise<tmp.SynchrounousResult>((resolve, reject) => {
-			tmp.file({ prefix: 'package-' }, (err, path, fd, cleanupCallback) => {
-				if (err) {
-					return reject(new Error('Error from tmp.file'));
-				}
+    private createTempFile(pkg: IPackage): Promise<tmp.SynchrounousResult> {
+        return new Promise<tmp.SynchrounousResult>((resolve, reject) => {
+            tmp.file({ prefix: 'package-' }, (err, path, fd, cleanupCallback) => {
+                if (err) {
+                    return reject(new Error('Error from tmp.file'));
+                }
 
-				resolve(<tmp.SynchrounousResult>{ name: path, fd: fd, removeCallback: cleanupCallback });
-			});
-		});
-	}
+                resolve(<tmp.SynchrounousResult>{ name: path, fd: fd, removeCallback: cleanupCallback });
+            });
+        });
+    }
 
-	private install(pkg: IPackage): Promise<void> {
-		this.eventEmitter.emit(Events.INSTALL_START, pkg.installPath);
-		return decompress(pkg.tmpFile.name, pkg.installPath).then(() => {
-			this.eventEmitter.emit(Events.INSTALL_END);
-		});
-	}
+    private install(pkg: IPackage): Promise<void> {
+        this.eventEmitter.emit(Events.INSTALL_START, pkg.installPath);
+        return decompress(pkg.tmpFile.name, pkg.installPath).then(() => {
+            this.eventEmitter.emit(Events.INSTALL_END);
+        });
+    }
 
-	private async withRetry(promiseToExecute: () => Promise<any>, retryOptions: IRetryOptions = { retries: 0 }): Promise<any> {
-		const promiseRetry = require('promise-retry');
-		// wrap function execution with a retry promise
-		// by default, it retries 10 times while backing off exponentially.
-		// retryOptions parameter can be used to configure, how many and how often the retries happen.
-		// https://www.npmjs.com/package/promise-retry
-		return await promiseRetry(retryOptions, async (retry, attemptNo) => {
-			try {
-				// run the main operation
-				return await promiseToExecute();
-			} catch (error) {
-				if (attemptNo <= retryOptions.retries) {
-					console.warn(`[${(new Date()).toLocaleTimeString('en-US', { hour12: false })}] `
-								 + `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
-				}
-				await retry(error);
-			}
-		});
-	}
+    private async withRetry(promiseToExecute: () => Promise<any>, retryOptions: IRetryOptions = { retries: 0 }): Promise<any> {
+        // wrap function execution with a retry promise
+        // by default, it retries 10 times while backing off exponentially.
+        // retryOptions parameter can be used to configure, how many and how often the retries happen.
+        // https://www.npmjs.com/package/promise-retry
+        return await AsyncRetry<any>(
+            async (bail: (e: Error) => void, attemptNo: number) => {
+                try {
+                    // run the main operation
+                    return await promiseToExecute();
+                } catch (error) {
+                    if (/403/.test(error)) {
+                        // don't retry upon 403
+                        bail(error);
+                        return;
+                    }
+                    if (attemptNo <= retryOptions.retries) {
+                        console.warn(`[${(new Date()).toLocaleTimeString('en-US', { hour12: false })}] `
+                                     + `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
+                    }
+                    // throw back any other error so it can get retried upon by AsyncRetry as appropriate
+                    throw error;
+                }
+            },
+            retryOptions
+        );
+    }
 }

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -93,8 +93,8 @@ export class ServiceDownloadProvider {
         const downloadAndInstall: () => Promise<void> = async () => {
             try {
                 pkg.tmpFile = await this.createTempFile(pkg);
-				console.info(`\tdownloading the package: ${pkg.url}`);
-				console.info(`\t                to file: ${pkg.tmpFile.name}`);
+                console.info(`\tdownloading the package: ${pkg.url}`);
+                console.info(`\t                to file: ${pkg.tmpFile.name}`);
                 await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
                 console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
                 await this.install(pkg);

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -93,7 +93,7 @@ export class ServiceDownloadProvider {
         const downloadAndInstall: () => Promise<void> = async () => {
             try {
                 pkg.tmpFile = await this.createTempFile(pkg);
-                console.info(`\tdownloading the package to file: ${pkg.tmpFile.name}`);
+                console.info(`\tdownloading the package: ${pkg.url} to file: ${pkg.tmpFile.name}`);
                 await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
                 console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
                 await this.install(pkg);

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,9 +18,21 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@types/async-retry@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.1.tgz#3b136a707b7a850f4947a727eb0f7b473b601992"
+  integrity sha512-hDI5Ttk9SUmDLcD/Yl2VuWQRGYZjJ7aaJFeRlomUOz/iTKSE7yA55SwY87QwjiZgwhMlVAKoT1rl08UyQoheag==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/node@^9.4.6":
   version "9.4.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.6.tgz#d8176d864ee48753d053783e4e463aec86b8d82e"
+
+"@types/retry@*":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/tmp@^0.0.33":
   version "0.0.33"
@@ -46,6 +58,13 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+async-retry@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.2.3.tgz#a6521f338358d322b1a0012b79030c6f411d1ce0"
+  integrity sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==
+  dependencies:
+    retry "0.12.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -192,11 +211,6 @@ end-of-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   dependencies:
     once "^1.4.0"
-
-err-code@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
-  integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
 
 es6-promise@^4.0.3:
   version "4.2.4"
@@ -414,14 +428,6 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-promise-retry@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
-  integrity sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=
-  dependencies:
-    err-code "^1.0.0"
-    retry "^0.10.0"
-
 readable-stream@^2.0.0, readable-stream@^2.0.5:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
@@ -441,10 +447,10 @@ resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.6"
 
-retry@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
-  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+retry@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,11 @@ end-of-stream@^1.0.0:
   dependencies:
     once "^1.4.0"
 
+err-code@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
+  integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
+
 es6-promise@^4.0.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
@@ -409,6 +414,14 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
+promise-retry@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
+  integrity sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=
+  dependencies:
+    err-code "^1.0.0"
+    retry "^0.10.0"
+
 readable-stream@^2.0.0, readable-stream@^2.0.5:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
@@ -427,6 +440,11 @@ resolve@^1.3.2:
   integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
   dependencies:
     path-parse "^1.0.6"
+
+retry@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"


### PR DESCRIPTION
This change adds a configurable feature to retry download and install operations. The configuration of whether to do retry and how many times with what delays are specified in the config file with a new optional field called 'retry'. 

Also took this opportunity to add code to cleanup all downloaded after execution of script is done in all error and success paths.