### PR TITLE
Use yauzl instead of decompress for unzipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "author": "anthonydresser",
   "license": "ISC",
   "devDependencies": {
-	"@types/async-retry": "^1.4.1",
-	"@types/mkdirp": "^0.5.1",
+    "@types/async-retry": "^1.4.1",
+    "@types/mkdirp": "^0.5.1",
     "@types/node": "^9.4.6",
-	"@types/tmp": "^0.0.33",
-	"@types/yauzl": "^2.9.1",
+    "@types/tmp": "^0.0.33",
+    "@types/yauzl": "^2.9.1",
     "husky": "^0.13.1",
     "tslint": "^5.16.0",
     "tslint-microsoft-contrib": "^6.0.0",
@@ -30,8 +30,8 @@
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.3",
     "mkdirp": "^0.5.1",
-	"tmp": "^0.0.33",
-	"yauzl": "^2.10.0"
+    "tmp": "^0.0.33",
+    "yauzl": "^2.10.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   "author": "anthonydresser",
   "license": "ISC",
   "devDependencies": {
-    "@types/async-retry": "^1.4.1",
+	"@types/async-retry": "^1.4.1",
+	"@types/mkdirp": "^0.5.1",
     "@types/node": "^9.4.6",
-    "@types/tmp": "^0.0.33",
+	"@types/tmp": "^0.0.33",
+	"@types/yauzl": "^2.9.1",
     "husky": "^0.13.1",
     "tslint": "^5.16.0",
     "tslint-microsoft-contrib": "^6.0.0",
@@ -24,12 +26,12 @@
   },
   "dependencies": {
     "async-retry": "^1.2.3",
-    "decompress": "^4.2.0",
     "eventemitter2": "^5.0.1",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.3",
     "mkdirp": "^0.5.1",
-    "tmp": "^0.0.33"
+	"tmp": "^0.0.33",
+	"yauzl": "^2.10.0"
   },
   "repository": {
     "type": "git",

--- a/src/async.ts
+++ b/src/async.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface ITask<T> {
+    (): T;
+}
+
+export class Sequencer {
+
+    private current: Promise<any> = Promise.resolve(null);
+
+    queue<T>(promiseTask: ITask<Promise<T>>): Promise<T> {
+        return this.current = this.current.then(() => promiseTask());
+    }
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -86,6 +86,10 @@ export const enum Events {
      */
     INSTALL_START = 'install_start',
     /**
+     * Entry extracted from downloaded archive, data will be path to file/folder
+     */
+    ENTRY_EXTRACTED = 'entry_extracted',
+    /**
      * Install End
      */
     INSTALL_END = 'install_end'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -86,7 +86,11 @@ export const enum Events {
      */
     INSTALL_START = 'install_start',
     /**
-     * Entry extracted from downloaded archive, data will be path to file/folder
+     * Entry extracted from downloaded archive.
+     * Data :
+     *  0 : Path to file/folder
+     *  1 : Entry number
+     *  2 : Total number of entries
      */
     ENTRY_EXTRACTED = 'entry_extracted',
     /**

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -5,7 +5,6 @@
 
 'use strict';
 import * as fs from 'fs';
-import * as decompress from 'decompress';
 import * as mkdirp from 'mkdirp';
 import { EventEmitter2 as EventEmitter } from 'eventemitter2';
 import * as tmp from 'tmp';
@@ -16,151 +15,156 @@ import { HttpClient } from './httpClient';
 import { PlatformNotSupportedError, DistributionNotSupportedError } from './errors';
 import { promisify } from 'util';
 import * as asyncRetry from 'async-retry';
+import { Unzipper } from './zip';
 /*
 * Service Download Provider class which handles downloading the service client
 */
 export class ServiceDownloadProvider {
 
-    private httpClient = new HttpClient();
-    public readonly eventEmitter = new EventEmitter({ wildcard: true });
+	private httpClient = new HttpClient();
+	private unzipper = new Unzipper();
+	public readonly eventEmitter = new EventEmitter({ wildcard: true });
 
-    constructor(
-        private _config: IConfig
-    ) {
-        // Ensure our temp files get cleaned up in case of error.
-        tmp.setGracefulCleanup();
-        this.httpClient.eventEmitter.onAny((e, ...args) => {
-            this.eventEmitter.emit(e, ...args);
-        });
-    }
+	constructor(
+		private _config: IConfig
+	) {
+		// Ensure our temp files get cleaned up in case of error.
+		tmp.setGracefulCleanup();
+		this.httpClient.eventEmitter.onAny((e, ...args) => {
+			this.eventEmitter.emit(e, ...args);
+		});
+		this.unzipper.eventEmitter.onAny((e, ...args) => {
+			this.eventEmitter.emit(e, ...args);
+		});
+	}
 
     /**
      * Returns the download url for given platform
      */
-    public getDownloadFileName(platform: Runtime): string {
-        let fileNamesJson = this._config.downloadFileNames;
-        let fileName = fileNamesJson[platform];
+	public getDownloadFileName(platform: Runtime): string {
+		let fileNamesJson = this._config.downloadFileNames;
+		let fileName = fileNamesJson[platform];
 
-        if (fileName === undefined) {
-            if (process.platform === 'linux') {
-                throw new DistributionNotSupportedError('Unsupported linux distribution', process.platform, platform.toString());
-            } else {
-                throw new PlatformNotSupportedError(`Unsupported platform: ${process.platform}`, process.platform);
-            }
-        }
+		if (fileName === undefined) {
+			if (process.platform === 'linux') {
+				throw new DistributionNotSupportedError('Unsupported linux distribution', process.platform, platform.toString());
+			} else {
+				throw new PlatformNotSupportedError(`Unsupported platform: ${process.platform}`, process.platform);
+			}
+		}
 
-        return fileName;
-    }
+		return fileName;
+	}
 
     /**
      * Returns SQL tools service installed folder.
      */
-    public getInstallDirectory(platform: Runtime): string {
-        let basePath = this._config.installDirectory;
-        let versionFromConfig = this._config.version;
-        basePath = basePath.replace('{#version#}', versionFromConfig);
-        basePath = basePath.replace('{#platform#}', getRuntimeDisplayName(platform));
-        if (!fs.existsSync(basePath)) {
-            mkdirp.sync(basePath);
-        }
+	public getInstallDirectory(platform: Runtime): string {
+		let basePath = this._config.installDirectory;
+		let versionFromConfig = this._config.version;
+		basePath = basePath.replace('{#version#}', versionFromConfig);
+		basePath = basePath.replace('{#platform#}', getRuntimeDisplayName(platform));
+		if (!fs.existsSync(basePath)) {
+			mkdirp.sync(basePath);
+		}
 
-        return basePath;
-    }
+		return basePath;
+	}
 
-    private getGetDownloadUrl(fileName: string): string {
-        let baseDownloadUrl = this._config.downloadUrl;
-        let version = this._config.version;
-        baseDownloadUrl = baseDownloadUrl.replace('{#version#}', version);
-        baseDownloadUrl = baseDownloadUrl.replace('{#fileName#}', fileName);
-        return baseDownloadUrl;
-    }
+	private getGetDownloadUrl(fileName: string): string {
+		let baseDownloadUrl = this._config.downloadUrl;
+		let version = this._config.version;
+		baseDownloadUrl = baseDownloadUrl.replace('{#version#}', version);
+		baseDownloadUrl = baseDownloadUrl.replace('{#fileName#}', fileName);
+		return baseDownloadUrl;
+	}
 
     /**
      * Downloads the service and decompress it in the install folder.
      */
-    public async installService(platform: Runtime): Promise<boolean> {
-        const proxy = this._config.proxy;
-        const strictSSL = this._config.strictSSL;
-        const fileName = this.getDownloadFileName(platform);
-        const installDirectory = this.getInstallDirectory(platform);
-        const urlString = this.getGetDownloadUrl(fileName);
+	public async installService(platform: Runtime): Promise<boolean> {
+		const proxy = this._config.proxy;
+		const strictSSL = this._config.strictSSL;
+		const fileName = this.getDownloadFileName(platform);
+		const installDirectory = this.getInstallDirectory(platform);
+		const urlString = this.getGetDownloadUrl(fileName);
 
-        const pkg: IPackage = {
-            installPath: installDirectory,
-            url: urlString,
-            tmpFile: undefined
-        };
+		const pkg: IPackage = {
+			installPath: installDirectory,
+			url: urlString,
+			tmpFile: undefined
+		};
 
-        const existsAsync = promisify(fs.exists);
-        const unlinkAsync = promisify(fs.unlink);
-        const downloadAndInstall: () => Promise<void> = async () => {
-            try {
-                pkg.tmpFile = await this.createTempFile(pkg);
-                console.info(`\tdownloading the package: ${pkg.url}`);
-                console.info(`\t                to file: ${pkg.tmpFile.name}`);
-                await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
-                console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
-                await this.install(pkg);
+		const existsAsync = promisify(fs.exists);
+		const unlinkAsync = promisify(fs.unlink);
+		const downloadAndInstall: () => Promise<void> = async () => {
+			try {
+				pkg.tmpFile = await this.createTempFile(pkg);
+				console.info(`\tdownloading the package: ${pkg.url}`);
+				console.info(`\t                to file: ${pkg.tmpFile.name}`);
+				await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
+				console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
+				await this.install(pkg);
 
-            } finally {
-                // remove the downloaded package file
-                if (await existsAsync(pkg.tmpFile.name)) {
-                    await unlinkAsync(pkg.tmpFile.name);
-                    console.info(`\tdeleted the package file: ${pkg.tmpFile.name}`);
-                }
-            }
-        };
+			} finally {
+				// remove the downloaded package file
+				if (await existsAsync(pkg.tmpFile.name)) {
+					await unlinkAsync(pkg.tmpFile.name);
+					console.info(`\tdeleted the package file: ${pkg.tmpFile.name}`);
+				}
+			}
+		};
 
-        // if this._config.retry is not defined then this.withRetry defaults to number of retries of 0
-        // which is same as without retries.
-        await withRetry(downloadAndInstall, this._config.retry);
-        return true;
-    }
+		// if this._config.retry is not defined then this.withRetry defaults to number of retries of 0
+		// which is same as without retries.
+		await withRetry(downloadAndInstall, this._config.retry);
+		return true;
+	}
 
-    private createTempFile(pkg: IPackage): Promise<tmp.SynchrounousResult> {
-        return new Promise<tmp.SynchrounousResult>((resolve, reject) => {
-            tmp.file({ prefix: 'package-' }, (err, path, fd, cleanupCallback) => {
-                if (err) {
-                    return reject(new Error('Error from tmp.file'));
-                }
+	private createTempFile(pkg: IPackage): Promise<tmp.SynchrounousResult> {
+		return new Promise<tmp.SynchrounousResult>((resolve, reject) => {
+			tmp.file({ prefix: 'package-' }, (err, path, fd, cleanupCallback) => {
+				if (err) {
+					return reject(new Error('Error from tmp.file'));
+				}
 
-                resolve(<tmp.SynchrounousResult>{ name: path, fd: fd, removeCallback: cleanupCallback });
-            });
-        });
-    }
+				resolve(<tmp.SynchrounousResult>{ name: path, fd: fd, removeCallback: cleanupCallback });
+			});
+		});
+	}
 
-    private install(pkg: IPackage): Promise<void> {
-        this.eventEmitter.emit(Events.INSTALL_START, pkg.installPath);
-        return decompress(pkg.tmpFile.name, pkg.installPath).then(() => {
-            this.eventEmitter.emit(Events.INSTALL_END);
-        });
-    }
+	private install(pkg: IPackage): Promise<void> {
+		this.eventEmitter.emit(Events.INSTALL_START, pkg.installPath);
+		return this.unzipper.extract(pkg.tmpFile.name, pkg.installPath).then(() => {
+			this.eventEmitter.emit(Events.INSTALL_END);
+		});
+	}
 }
 
 async function withRetry(promiseToExecute: () => Promise<any>, retryOptions: IRetryOptions = { retries: 0 }): Promise<any> {
-    // wrap function execution with a retry promise
-    // by default, it retries 10 times while backing off exponentially.
-    // retryOptions parameter can be used to configure how many and how often the retries happen.
-    // https://www.npmjs.com/package/promise-retry
-    return await asyncRetry<any>(
-        async (bail: (e: Error) => void, attemptNo: number) => {
-            try {
-                // run the main operation
-                return await promiseToExecute();
-            } catch (error) {
-                if (/403/.test(error)) {
-                    // don't retry upon 403
-                    bail(error);
-                    return;
-                }
-                if (attemptNo <= retryOptions.retries) {
-                    console.warn(`[${(new Date()).toLocaleTimeString('en-US', { hour12: false })}] `
-                        + `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
-                }
-                // throw back any other error so it can get retried by asyncRetry as appropriate
-                throw error;
-            }
-        },
-        retryOptions
-    );
+	// wrap function execution with a retry promise
+	// by default, it retries 10 times while backing off exponentially.
+	// retryOptions parameter can be used to configure how many and how often the retries happen.
+	// https://www.npmjs.com/package/promise-retry
+	return await asyncRetry<any>(
+		async (bail: (e: Error) => void, attemptNo: number) => {
+			try {
+				// run the main operation
+				return await promiseToExecute();
+			} catch (error) {
+				if (/403/.test(error)) {
+					// don't retry upon 403
+					bail(error);
+					return;
+				}
+				if (attemptNo <= retryOptions.retries) {
+					console.warn(`[${(new Date()).toLocaleTimeString('en-US', { hour12: false })}] `
+						+ `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
+				}
+				// throw back any other error so it can get retried by asyncRetry as appropriate
+				throw error;
+			}
+		},
+		retryOptions
+	);
 }

--- a/src/serviceDownloadProvider.ts
+++ b/src/serviceDownloadProvider.ts
@@ -21,150 +21,150 @@ import { Unzipper } from './zip';
 */
 export class ServiceDownloadProvider {
 
-	private httpClient = new HttpClient();
-	private unzipper = new Unzipper();
-	public readonly eventEmitter = new EventEmitter({ wildcard: true });
+    private httpClient = new HttpClient();
+    private unzipper = new Unzipper();
+    public readonly eventEmitter = new EventEmitter({ wildcard: true });
 
-	constructor(
-		private _config: IConfig
-	) {
-		// Ensure our temp files get cleaned up in case of error.
-		tmp.setGracefulCleanup();
-		this.httpClient.eventEmitter.onAny((e, ...args) => {
-			this.eventEmitter.emit(e, ...args);
-		});
-		this.unzipper.eventEmitter.onAny((e, ...args) => {
-			this.eventEmitter.emit(e, ...args);
-		});
-	}
+    constructor(
+        private _config: IConfig
+    ) {
+        // Ensure our temp files get cleaned up in case of error.
+        tmp.setGracefulCleanup();
+        this.httpClient.eventEmitter.onAny((e, ...args) => {
+            this.eventEmitter.emit(e, ...args);
+        });
+        this.unzipper.eventEmitter.onAny((e, ...args) => {
+            this.eventEmitter.emit(e, ...args);
+        });
+    }
 
     /**
      * Returns the download url for given platform
      */
-	public getDownloadFileName(platform: Runtime): string {
-		let fileNamesJson = this._config.downloadFileNames;
-		let fileName = fileNamesJson[platform];
+    public getDownloadFileName(platform: Runtime): string {
+        let fileNamesJson = this._config.downloadFileNames;
+        let fileName = fileNamesJson[platform];
 
-		if (fileName === undefined) {
-			if (process.platform === 'linux') {
-				throw new DistributionNotSupportedError('Unsupported linux distribution', process.platform, platform.toString());
-			} else {
-				throw new PlatformNotSupportedError(`Unsupported platform: ${process.platform}`, process.platform);
-			}
-		}
+        if (fileName === undefined) {
+            if (process.platform === 'linux') {
+                throw new DistributionNotSupportedError('Unsupported linux distribution', process.platform, platform.toString());
+            } else {
+                throw new PlatformNotSupportedError(`Unsupported platform: ${process.platform}`, process.platform);
+            }
+        }
 
-		return fileName;
-	}
+        return fileName;
+    }
 
     /**
      * Returns SQL tools service installed folder.
      */
-	public getInstallDirectory(platform: Runtime): string {
-		let basePath = this._config.installDirectory;
-		let versionFromConfig = this._config.version;
-		basePath = basePath.replace('{#version#}', versionFromConfig);
-		basePath = basePath.replace('{#platform#}', getRuntimeDisplayName(platform));
-		if (!fs.existsSync(basePath)) {
-			mkdirp.sync(basePath);
-		}
+    public getInstallDirectory(platform: Runtime): string {
+        let basePath = this._config.installDirectory;
+        let versionFromConfig = this._config.version;
+        basePath = basePath.replace('{#version#}', versionFromConfig);
+        basePath = basePath.replace('{#platform#}', getRuntimeDisplayName(platform));
+        if (!fs.existsSync(basePath)) {
+            mkdirp.sync(basePath);
+        }
 
-		return basePath;
-	}
+        return basePath;
+    }
 
-	private getGetDownloadUrl(fileName: string): string {
-		let baseDownloadUrl = this._config.downloadUrl;
-		let version = this._config.version;
-		baseDownloadUrl = baseDownloadUrl.replace('{#version#}', version);
-		baseDownloadUrl = baseDownloadUrl.replace('{#fileName#}', fileName);
-		return baseDownloadUrl;
-	}
+    private getGetDownloadUrl(fileName: string): string {
+        let baseDownloadUrl = this._config.downloadUrl;
+        let version = this._config.version;
+        baseDownloadUrl = baseDownloadUrl.replace('{#version#}', version);
+        baseDownloadUrl = baseDownloadUrl.replace('{#fileName#}', fileName);
+        return baseDownloadUrl;
+    }
 
     /**
      * Downloads the service and decompress it in the install folder.
      */
-	public async installService(platform: Runtime): Promise<boolean> {
-		const proxy = this._config.proxy;
-		const strictSSL = this._config.strictSSL;
-		const fileName = this.getDownloadFileName(platform);
-		const installDirectory = this.getInstallDirectory(platform);
-		const urlString = this.getGetDownloadUrl(fileName);
+    public async installService(platform: Runtime): Promise<boolean> {
+        const proxy = this._config.proxy;
+        const strictSSL = this._config.strictSSL;
+        const fileName = this.getDownloadFileName(platform);
+        const installDirectory = this.getInstallDirectory(platform);
+        const urlString = this.getGetDownloadUrl(fileName);
 
-		const pkg: IPackage = {
-			installPath: installDirectory,
-			url: urlString,
-			tmpFile: undefined
-		};
+        const pkg: IPackage = {
+            installPath: installDirectory,
+            url: urlString,
+            tmpFile: undefined
+        };
 
-		const existsAsync = promisify(fs.exists);
-		const unlinkAsync = promisify(fs.unlink);
-		const downloadAndInstall: () => Promise<void> = async () => {
-			try {
-				pkg.tmpFile = await this.createTempFile(pkg);
-				console.info(`\tdownloading the package: ${pkg.url}`);
-				console.info(`\t                to file: ${pkg.tmpFile.name}`);
-				await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
-				console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
-				await this.install(pkg);
+        const existsAsync = promisify(fs.exists);
+        const unlinkAsync = promisify(fs.unlink);
+        const downloadAndInstall: () => Promise<void> = async () => {
+            try {
+                pkg.tmpFile = await this.createTempFile(pkg);
+                console.info(`\tdownloading the package: ${pkg.url}`);
+                console.info(`\t                to file: ${pkg.tmpFile.name}`);
+                await this.httpClient.downloadFile(pkg.url, pkg, proxy, strictSSL);
+                console.info(`\tinstalling the package from file: ${pkg.tmpFile.name}`);
+                await this.install(pkg);
 
-			} finally {
-				// remove the downloaded package file
-				if (await existsAsync(pkg.tmpFile.name)) {
-					await unlinkAsync(pkg.tmpFile.name);
-					console.info(`\tdeleted the package file: ${pkg.tmpFile.name}`);
-				}
-			}
-		};
+            } finally {
+                // remove the downloaded package file
+                if (await existsAsync(pkg.tmpFile.name)) {
+                    await unlinkAsync(pkg.tmpFile.name);
+                    console.info(`\tdeleted the package file: ${pkg.tmpFile.name}`);
+                }
+            }
+        };
 
-		// if this._config.retry is not defined then this.withRetry defaults to number of retries of 0
-		// which is same as without retries.
-		await withRetry(downloadAndInstall, this._config.retry);
-		return true;
-	}
+        // if this._config.retry is not defined then this.withRetry defaults to number of retries of 0
+        // which is same as without retries.
+        await withRetry(downloadAndInstall, this._config.retry);
+        return true;
+    }
 
-	private createTempFile(pkg: IPackage): Promise<tmp.SynchrounousResult> {
-		return new Promise<tmp.SynchrounousResult>((resolve, reject) => {
-			tmp.file({ prefix: 'package-' }, (err, path, fd, cleanupCallback) => {
-				if (err) {
-					return reject(new Error('Error from tmp.file'));
-				}
+    private createTempFile(pkg: IPackage): Promise<tmp.SynchrounousResult> {
+        return new Promise<tmp.SynchrounousResult>((resolve, reject) => {
+            tmp.file({ prefix: 'package-' }, (err, path, fd, cleanupCallback) => {
+                if (err) {
+                    return reject(new Error('Error from tmp.file'));
+                }
 
-				resolve(<tmp.SynchrounousResult>{ name: path, fd: fd, removeCallback: cleanupCallback });
-			});
-		});
-	}
+                resolve(<tmp.SynchrounousResult>{ name: path, fd: fd, removeCallback: cleanupCallback });
+            });
+        });
+    }
 
-	private install(pkg: IPackage): Promise<void> {
-		this.eventEmitter.emit(Events.INSTALL_START, pkg.installPath);
-		return this.unzipper.extract(pkg.tmpFile.name, pkg.installPath).then(() => {
-			this.eventEmitter.emit(Events.INSTALL_END);
-		});
-	}
+    private install(pkg: IPackage): Promise<void> {
+        this.eventEmitter.emit(Events.INSTALL_START, pkg.installPath);
+        return this.unzipper.extract(pkg.tmpFile.name, pkg.installPath).then(() => {
+            this.eventEmitter.emit(Events.INSTALL_END);
+        });
+    }
 }
 
 async function withRetry(promiseToExecute: () => Promise<any>, retryOptions: IRetryOptions = { retries: 0 }): Promise<any> {
-	// wrap function execution with a retry promise
-	// by default, it retries 10 times while backing off exponentially.
-	// retryOptions parameter can be used to configure how many and how often the retries happen.
-	// https://www.npmjs.com/package/promise-retry
-	return await asyncRetry<any>(
-		async (bail: (e: Error) => void, attemptNo: number) => {
-			try {
-				// run the main operation
-				return await promiseToExecute();
-			} catch (error) {
-				if (/403/.test(error)) {
-					// don't retry upon 403
-					bail(error);
-					return;
-				}
-				if (attemptNo <= retryOptions.retries) {
-					console.warn(`[${(new Date()).toLocaleTimeString('en-US', { hour12: false })}] `
-						+ `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
-				}
-				// throw back any other error so it can get retried by asyncRetry as appropriate
-				throw error;
-			}
-		},
-		retryOptions
-	);
+    // wrap function execution with a retry promise
+    // by default, it retries 10 times while backing off exponentially.
+    // retryOptions parameter can be used to configure how many and how often the retries happen.
+    // https://www.npmjs.com/package/promise-retry
+    return await asyncRetry<any>(
+        async (bail: (e: Error) => void, attemptNo: number) => {
+            try {
+                // run the main operation
+                return await promiseToExecute();
+            } catch (error) {
+                if (/403/.test(error)) {
+                    // don't retry upon 403
+                    bail(error);
+                    return;
+                }
+                if (attemptNo <= retryOptions.retries) {
+                    console.warn(`[${(new Date()).toLocaleTimeString('en-US', { hour12: false })}] `
+                        + `Retrying...   as attempt:${attemptNo} to run '${promiseToExecute.name}' failed with: '${error}'.`);
+                }
+                // throw back any other error so it can get retried by asyncRetry as appropriate
+                throw error;
+            }
+        },
+        retryOptions
+    );
 }

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { open as _openZip, Entry, ZipFile } from 'yauzl';
+import * as path from 'path';
+import * as _mkdirp from 'mkdirp';
+import { Sequencer } from './async';
+import { Readable } from 'stream';
+import { WriteStream, createWriteStream } from 'fs';
+import { promisify } from 'util';
+import { EventEmitter2 as EventEmitter } from 'eventemitter2';
+import { Events } from './interfaces';
+
+const mkdirp = promisify(_mkdirp);
+
+export type ExtractErrorType = 'CorruptZip' | 'Incomplete';
+
+export class ExtractError extends Error {
+
+    readonly type?: ExtractErrorType;
+    readonly cause: Error;
+
+    constructor(type: ExtractErrorType | undefined, cause: Error) {
+        let message = cause.message;
+        if (type === 'CorruptZip') {
+            message = `Corrupt ZIP: ${message}`;
+        }
+
+        super(message);
+        this.type = type;
+        this.cause = cause;
+    }
+}
+
+/**
+ * Helper class to handle unzipping the contents of a zip archive into a specified directory.
+ *
+ * Code adapted from https://github.com/microsoft/vscode/blob/6ffa7d5887e60244169ef9699842ff276216be10/src/vs/base/node/zip.ts
+ */
+export class Unzipper {
+
+    public readonly eventEmitter = new EventEmitter({ wildcard: true });
+
+    public extract(zipPath: string, targetPath: string): Promise<void> {
+        let promise = this.openZip(zipPath, true);
+
+        return promise.then(zipfile => this.extractZip(zipfile, targetPath));
+    }
+
+    private openZip(zipFile: string, lazy: boolean = false): Promise<ZipFile> {
+        return new Promise((resolve, reject) => {
+            _openZip(zipFile, lazy ? { lazyEntries: true } : undefined!, (error?: Error, zipfile?: ZipFile) => {
+                if (error) {
+                    reject(toExtractError(error));
+                } else {
+                    resolve(zipfile);
+                }
+            });
+        });
+    }
+
+    private extractZip(zipfile: ZipFile, targetPath: string): Promise<void> {
+        let extractedEntriesCount = 0;
+
+        return new Promise((c, e) => {
+            const throttler = new Sequencer();
+
+            const readNextEntry = () => {
+                extractedEntriesCount++;
+                zipfile.readEntry();
+            };
+
+            zipfile.once('error', e);
+            zipfile.once('close', () => {
+                if (zipfile.entryCount === extractedEntriesCount) {
+                    c();
+                } else {
+                    e(new ExtractError('Incomplete', new Error(`Incomplete. Found ${extractedEntriesCount} of ${zipfile.entryCount} entries`)));
+                }
+            });
+            zipfile.readEntry();
+            zipfile.on('entry', (entry: Entry) => {
+                // directory file names end with '/'
+                if (/\/$/.test(entry.fileName)) {
+                    const targetFileName = path.join(targetPath, entry.fileName);
+                    mkdirp(targetFileName).then(() => readNextEntry()).then(undefined, e);
+                    return;
+                }
+
+                const stream = this.openZipStream(zipfile, entry);
+                const mode = modeFromEntry(entry);
+
+                throttler.queue(() => stream.then(readable => this.extractEntry(readable, entry.fileName, mode, targetPath).then(() => readNextEntry())))
+                    .then(undefined, e);
+            });
+        });
+    }
+
+    private extractEntry(stream: Readable, fileName: string, mode: number, targetPath: string): Promise<void> {
+        const dirName = path.dirname(fileName);
+        const targetDirName = path.join(targetPath, dirName);
+        if (targetDirName.indexOf(targetPath) !== 0) {
+            return Promise.reject(new Error(`Error extracting ${fileName}. Invalid file.`));
+        }
+        const targetFileName = path.join(targetPath, fileName);
+
+        let istream: WriteStream;
+
+        return Promise.resolve(mkdirp(targetDirName)).then(() => new Promise<void>((c, e) => {
+            try {
+                istream = createWriteStream(targetFileName, { mode });
+                istream.once('close', () => {
+                    this.eventEmitter.emit(Events.ENTRY_EXTRACTED, targetFileName);
+                    c();
+                });
+                istream.once('error', e);
+                stream.once('error', e);
+                stream.pipe(istream);
+            } catch (error) {
+                e(error);
+            }
+        }));
+    }
+
+    private openZipStream(zipFile: ZipFile, entry: Entry): Promise<Readable> {
+        return new Promise((resolve, reject) => {
+            zipFile.openReadStream(entry, (error?: Error, stream?: Readable) => {
+                if (error) {
+                    reject(toExtractError(error));
+                } else {
+                    resolve(stream);
+                }
+            });
+        });
+    }
+}
+
+function toExtractError(err: Error): ExtractError {
+    if (err instanceof ExtractError) {
+        return err;
+    }
+
+    let type: ExtractErrorType | undefined = undefined;
+
+    if (/end of central directory record signature not found/.test(err.message)) {
+        type = 'CorruptZip';
+    }
+
+    return new ExtractError(type, err);
+}
+
+// tslint:disable: no-bitwise
+function modeFromEntry(entry: Entry): number {
+    const attr = entry.externalFileAttributes >> 16 || 33188;
+
+    return [448 /* S_IRWXU */, 56 /* S_IRWXG */, 7 /* S_IRWXO */]
+        .map(mask => attr & mask)
+        .reduce((a, b) => a + b, attr & 61440 /* S_IFMT */);
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,18 @@
   dependencies:
     "@types/retry" "*"
 
+"@types/mkdirp@^0.5.1":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
+  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*":
+  version "13.7.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.4.tgz#76c3cb3a12909510f52e5dc04a6298cdf9504ffd"
+  integrity sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==
+
 "@types/node@^9.4.6":
   version "9.4.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.6.tgz#d8176d864ee48753d053783e4e463aec86b8d82e"
@@ -39,13 +51,14 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
   integrity sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=
 
-agent-base@4:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+"@types/yauzl@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   dependencies:
-    es6-promisify "^5.0.0"
+    "@types/node" "*"
 
-agent-base@^4.3.0:
+agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
   integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
@@ -88,16 +101,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
-
-bl@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.1.tgz#cac328f7bee45730d404b692203fcb590e172d5e"
-  dependencies:
-    readable-stream "^2.0.5"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -109,14 +112,6 @@ brace-expansion@^1.1.7:
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-
-buffer@^3.0.1:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-3.6.0.tgz#a72c936f77b96bf52f5f7e7b467180628551defb"
-  dependencies:
-    base64-js "0.0.8"
-    ieee754 "^1.1.4"
-    isarray "^1.0.0"
 
 builtin-modules@^1.1.1:
   version "1.1.1"
@@ -165,93 +160,39 @@ commander@^2.12.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
-commander@~2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-core-util-is@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-debug@3.1.0, debug@^3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
-decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
+debug@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
-    file-type "^5.2.0"
-    is-stream "^1.1.0"
-    tar-stream "^1.5.2"
-
-decompress-tarbz2@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz#3082a5b880ea4043816349f378b56c516be1a39b"
-  dependencies:
-    decompress-tar "^4.1.0"
-    file-type "^6.1.0"
-    is-stream "^1.1.0"
-    seek-bzip "^1.0.5"
-    unbzip2-stream "^1.0.9"
-
-decompress-targz@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/decompress-targz/-/decompress-targz-4.1.1.tgz#c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee"
-  dependencies:
-    decompress-tar "^4.1.1"
-    file-type "^5.2.0"
-    is-stream "^1.1.0"
-
-decompress-unzip@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/decompress-unzip/-/decompress-unzip-4.0.1.tgz#deaaccdfd14aeaf85578f733ae8210f9b4848f69"
-  dependencies:
-    file-type "^3.8.0"
-    get-stream "^2.2.0"
-    pify "^2.3.0"
-    yauzl "^2.4.2"
-
-decompress@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
-  dependencies:
-    decompress-tar "^4.0.0"
-    decompress-tarbz2 "^4.0.0"
-    decompress-targz "^4.0.0"
-    decompress-unzip "^4.0.1"
-    graceful-fs "^4.1.10"
-    make-dir "^1.0.0"
-    pify "^2.3.0"
-    strip-dirs "^2.0.0"
+    ms "^2.1.1"
 
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
-end-of-stream@^1.0.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
-  dependencies:
-    once "^1.4.0"
-
 es6-promise@^4.0.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
 
 es6-promisify@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
 
@@ -274,23 +215,12 @@ eventemitter2@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-5.0.1.tgz#6197a095d5fb6b57e8942f6fd7eaad63a09c9452"
 
-fd-slicer@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
-
-file-type@^3.8.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
-
-file-type@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
-
-file-type@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
 
 find-parent-dir@^0.3.0:
   version "0.3.0"
@@ -301,13 +231,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-
-get-stream@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
-  dependencies:
-    object-assign "^4.0.1"
-    pinkie-promise "^2.0.0"
 
 glob@^7.1.1:
   version "7.1.4"
@@ -320,14 +243,6 @@ glob@^7.1.1:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-graceful-fs@^4.1.10:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -344,6 +259,7 @@ has-flag@^3.0.0:
 http-proxy-agent@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
   dependencies:
     agent-base "4"
     debug "3.1.0"
@@ -366,10 +282,6 @@ husky@^0.13.1:
     is-ci "^1.0.9"
     normalize-path "^1.0.0"
 
-ieee754@^1.1.4:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -378,7 +290,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.3:
+inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -388,18 +300,6 @@ is-ci@^1.0.9:
   integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
     ci-info "^1.5.0"
-
-is-natural-number@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
-
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-isarray@^1.0.0, isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -413,12 +313,6 @@ js-yaml@^3.13.0:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-make-dir@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.2.0.tgz#6d6a49eead4aae296c53bbf3a1a008bd6c89469b"
-  dependencies:
-    pify "^3.0.0"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -440,17 +334,19 @@ mkdirp@^0.5.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 normalize-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
   integrity sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=
 
-object-assign@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -474,40 +370,6 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
-pify@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-
-pify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  dependencies:
-    pinkie "^2.0.0"
-
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-
-process-nextick-args@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
-
-readable-stream@^2.0.0, readable-stream@^2.0.5:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
 resolve@^1.3.2:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
@@ -520,16 +382,6 @@ retry@0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-
-seek-bzip@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
-  dependencies:
-    commander "~2.8.1"
-
 semver@^5.3.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
@@ -540,24 +392,12 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
-  dependencies:
-    safe-buffer "~5.1.0"
-
 strip-ansi@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-dirs@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/strip-dirs/-/strip-dirs-2.1.0.tgz#4987736264fc344cf20f6c34aca9d13d1d4ed6c5"
-  dependencies:
-    is-natural-number "^4.0.1"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -570,19 +410,6 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
-
-tar-stream@^1.5.2:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
-  dependencies:
-    bl "^1.0.0"
-    end-of-stream "^1.0.0"
-    readable-stream "^2.0.0"
-    xtend "^4.0.0"
-
-through@^2.3.6:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -639,28 +466,14 @@ typescript@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
-unbzip2-stream@^1.0.9:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz#73a033a567bbbde59654b193c44d48a7e4f43c47"
-  dependencies:
-    buffer "^3.0.1"
-    through "^2.3.6"
-
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-xtend@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-yauzl@^2.4.2:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.9.1.tgz#a81981ea70a57946133883f029c5821a89359a7f"
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
   dependencies:
     buffer-crc32 "~0.2.3"
-    fd-slicer "~1.0.1"
+    fd-slicer "~1.1.0"


### PR DESCRIPTION
This is an attempt to fix the issues seen where the extraction doesn't seem to actually be finished when the promise resolves. 

There's an open issue in the repo indicating that we're not the only ones hitting this issue and since it's been years since it's been updated moving away from decompress seems prudent. https://github.com/kevva/decompress/issues/62

Code adapted from VS Codes usage of the yauzl library : https://github.com/microsoft/vscode/blob/6ffa7d5887e60244169ef9699842ff276216be10/src/vs/base/node/zip.ts

Also added event for an entry being extracted from the zip for debugging/tracking purposes. 